### PR TITLE
swapped icu with ventilation

### DIFF
--- a/docs/src/base-disease.md
+++ b/docs/src/base-disease.md
@@ -44,9 +44,9 @@ As the symptom category and terminal state are closely related, the terms
 "symptomatic".
 
 Furthermore the progression for some symptom categories includes the need of hospitalization.
-Severe cases will have a given probability to need hospitalization, while criticl cases
-will always be hospitalized. Critical case furthermore have probability to need ventilation.
-Ventilated critical case have also a probability to need ICU (intensive care unit).
+Severe cases will have a given probability to need hospitalization, while critical cases
+will always be hospitalized. Critical case furthermore have probability to need ICU (intensive care unit).
+Critical ICU cases also have a probability to need ventilation.
 
 While asymptotic cases can't die by means of the disease, all other symptom categories
 are assigned a certain death probability as seen in the graphic.

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -13,7 +13,7 @@
 | Generation Time | The time interval between the infections of the infector and infectee, two immediate successors in an infection chain. |
 | Hospitalization Status | States if an individual is hospitalized and if additional measures have to be applied (vetilation, ICU). |
 | Hospitalization Rate | The probability of an individual with severe symptoms to need hospitalization. |
-| ICU | Short for Intensive Care Unit. An hospitalization state. Individuals are in the hospital, ventilated and are in ICU. |
+| ICU | Short for Intensive Care Unit. An hospitalization state. Individuals are in the hospital and in the ICU. |
 | ICU Rate | The probabilityof an individual in critical condition to need ICU. |
 | Individual | The representation of a person. It has different attributes and can become infected inside settings. |
 | Infection Rate | Basic risk of getting infected upon infectious contact |
@@ -44,5 +44,5 @@
 | Time to Hospitalization | If an individual will need hospitalization eventually, this defines the time between the onset of symptoms and hospitalization. |
 | Time to ICU | If an individual will need ICU eventually, this defines the time between the time to hospitalization and the delivery into ICU. |
 | Time to Recovery | The time it takes an individual to recover from an infection as an increment from the onset of symptoms. If an individual will die at the end of the natural disease progression, this will (also) define the time of death. |
-| Ventilated | An hospitalization state. Individuals are in the hospital and receive ventilation. |
-| Ventilation Rate | The probability of an individual in critical condition to need ventilation. |
+| Ventilated | An hospitalization state. Individuals are in the hospital, in the ICU and receive ventilation. |
+| Ventilation Rate | The probability of an individual in the ICU to need ventilation. |

--- a/src/methods/disease_progression.jl
+++ b/src/methods/disease_progression.jl
@@ -435,20 +435,22 @@ function disease_progression!(
         hospitalized_tick(infectee) + sample_length_of_stay(pathogen, infectee)
     )
 
-    # random value to determine ventilation. If yes, directly when hospitalized.
-    ventilation_probability = sample_ventilation_rate(pathogen, infectee)
-    if rand() < ventilation_probability
-        ventilation_tick!(infectee, hospitalized_tick(infectee))
 
-        # ICU only if ventilated and determined randomly. Then ICU tick as increment on hospitalization tick
-        icu_probability = sample_icu_rate(pathogen, infectee)
-        if rand()<icu_probability
-            icu_tick!(
-                infectee,
-                hospitalized_tick(infectee) + sample_time_to_icu(pathogen, infectee)
-            )
+    # random value to determine icu admission. If yes, sample offset from hospitalization
+    icu_probability = sample_icu_rate(pathogen, infectee)
+    if rand() < icu_probability
+        icu_tick!(
+            infectee,
+            hospitalized_tick(infectee) + sample_time_to_icu(pathogen, infectee)
+        )
+
+        # Ventilation only if in ICU. If yes, directly ventilate when admitted to ICU.
+        ventilation_probability = sample_ventilation_rate(pathogen, infectee)
+        if rand() < ventilation_probability
+            ventilation_tick!(infectee, icu_tick(infectee))
         end
     end
+
 
     #=
     # hospital is a form of quarantine

--- a/test/diseaseprogressiontest.jl
+++ b/test/diseaseprogressiontest.jl
@@ -232,15 +232,15 @@
             reset!(ind)
             Random.seed!(42)
             disease_progression!(ind, p, exposedtick, GEMS.Critical)
-            @test ventilation_tick(ind) == hospitalized_tick(ind)
+            @test ventilation_tick(ind) >= hospitalized_tick(ind) || ventilation_tick(ind) == -1
             @test death_tick(ind) == GEMS.DEFAULT_TICK
             @test icu_tick(ind) == GEMS.DEFAULT_TICK
 
             # ventilation and death
             reset!(ind)
-            Random.seed!(312)
+            Random.seed!(13)
             disease_progression!(ind, p, exposedtick, GEMS.Critical)
-            @test ventilation_tick(ind) == hospitalized_tick(ind)
+            @test ventilation_tick(ind) >= hospitalized_tick(ind) || ventilation_tick(ind) == -1
             @test death_tick(ind) == removed_tick(ind) 
             @test icu_tick(ind) == GEMS.DEFAULT_TICK
 
@@ -249,18 +249,18 @@
             reset!(ind)
             Random.seed!(42)
             disease_progression!(ind, p, exposedtick, GEMS.Critical)
-            @test ventilation_tick(ind) == hospitalized_tick(ind)
+            @test ventilation_tick(ind) >= hospitalized_tick(ind) || ventilation_tick(ind) == -1
             @test death_tick(ind) == GEMS.DEFAULT_TICK
-            @test removed_tick(ind) >= icu_tick(ind) >= ventilation_tick(ind)
+            @test removed_tick(ind) >= ventilation_tick(ind) >= icu_tick(ind)
 
             # ICU and death
             p.critical_death_rate = Uniform(0.98,0.99)
             reset!(ind)
             Random.seed!(42)
             disease_progression!(ind, p, exposedtick, GEMS.Critical)
-            @test ventilation_tick(ind) == hospitalized_tick(ind)
+            @test ventilation_tick(ind) >= hospitalized_tick(ind) || ventilation_tick(ind) == -1
             @test death_tick(ind) == removed_tick(ind)
-            @test removed_tick(ind) >= icu_tick(ind) >= ventilation_tick(ind)
+            @test removed_tick(ind) >= ventilation_tick(ind) >= icu_tick(ind)
         end
     end
     @testset "Agent-Level Updates" begin


### PR DESCRIPTION
before:
Individuals were ventilated upon admission to hospital. Those who were ventilated had a chance of being admitted to the ICU later.

now:
First, it is determined whether an individual is admitted to the ICU. Individuals admitted to the ICU have a probability to be ventilated immediately.

